### PR TITLE
Add map preview and fix dashboard route

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -19,7 +19,7 @@ const App: React.FC = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Layout />}>
+        <Route path="/" element={<Layout />}> 
           <Route index element={<Navigate to={ROUTES.DASHBOARD} replace />} />
           <Route path={ROUTES.DASHBOARD} element={<DashboardPage />} />
           

--- a/components/maps/MapPreview.tsx
+++ b/components/maps/MapPreview.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface MapPreviewProps {
+  address: string;
+}
+
+const MapPreview: React.FC<MapPreviewProps> = ({ address }) => {
+  const encodedAddress = encodeURIComponent(address);
+  const mapSrc = `https://www.google.com/maps?q=${encodedAddress}&t=k&z=17&output=embed`;
+  const mapLink = `https://www.google.com/maps/search/?api=1&query=${encodedAddress}`;
+  return (
+    <div className="mt-4">
+      <iframe
+        title="Mapa"
+        src={mapSrc}
+        className="w-full h-64 rounded-md border"
+        loading="lazy"
+        referrerPolicy="no-referrer-when-downgrade"
+      />
+      <div className="text-right mt-1">
+        <a href={mapLink} target="_blank" rel="noopener noreferrer" className="text-sm text-primary hover:underline">
+          Ver rotas no Maps
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default MapPreview;

--- a/constants.ts
+++ b/constants.ts
@@ -9,7 +9,7 @@ export const APP_NAME = "ArchiEng Dashboard";
 // Using process.env.API_KEY directly as per guidelines.
 
 export const ROUTES = {
-  DASHBOARD: "/",
+  DASHBOARD: "/dashboard",
   INSPECTIONS: "/inspections",
   INSPECTION_DETAIL: "/inspections/:id",
   NEW_INSPECTION: "/inspections/new",

--- a/pages/InspectionDetailPage.tsx
+++ b/pages/InspectionDetailPage.tsx
@@ -8,6 +8,7 @@ import { generateInspectionPdf } from '../services/reportService';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import PhotoUpload from '../components/inspections/PhotoUpload';
 import PhotoChecklist from '../components/inspections/PhotoChecklist';
+import MapPreview from '../components/maps/MapPreview';
 import { ROUTES } from '../constants';
 import Modal from '../components/ui/Modal';
 
@@ -217,6 +218,7 @@ const InspectionDetailPage: React.FC = () => {
           <p><strong className="text-neutral-dark">Agendada para:</strong> {new Date(inspection.scheduledDate).toLocaleString('pt-BR')}</p>
           <p><strong className="text-neutral-dark">Vistoriador:</strong> {inspection.inspectorName || 'Não atribuído'}</p>
         </div>
+        <MapPreview address={inspection.address} />
 
         <div className="mt-4">
           <label htmlFor="status" className="block text-sm font-medium text-neutral-dark">Alterar Status:</label>


### PR DESCRIPTION
## Summary
- embed map preview on inspection detail
- change dashboard route to `/dashboard`
- fix initial redirect to avoid blank page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f33a46d708322bc43ef1ee0174af1