### PR TITLE
Add laudo form page with inspection template

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import InspectionsListPage from './pages/InspectionsListPage';
 import InspectionDetailPage from './pages/InspectionDetailPage';
 import NewInspectionPage from './pages/NewInspectionPage';
 import ReportsPage from './pages/ReportsPage';
+import InspectionReportFormPage from './pages/InspectionReportFormPage';
 import ClientsPage from './pages/ClientsPage';
 import NewClientPage from './pages/NewClientPage'; // New Page for creating clients
 import ClientDetailPage from './pages/ClientDetailPage'; // New Page for client details
@@ -25,6 +26,7 @@ const App: React.FC = () => {
           
           <Route path={ROUTES.INSPECTIONS} element={<InspectionsListPage />} />
           <Route path={ROUTES.INSPECTION_DETAIL} element={<InspectionDetailPage />} />
+          <Route path={ROUTES.INSPECTION_REPORT_FORM} element={<InspectionReportFormPage />} />
           <Route path={ROUTES.NEW_INSPECTION} element={<NewInspectionPage />} />
           
           <Route path={ROUTES.CLIENTS} element={<ClientsPage />} />

--- a/components/reports/InspectionForm.tsx
+++ b/components/reports/InspectionForm.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { COMPLETE_INSPECTION_SECTIONS, InspectionField } from '../../inspectionTemplate';
+
+interface InspectionFormProps {
+  answers: Record<string, string | number | boolean>;
+  onChange: (fieldId: string, value: string | number | boolean) => void;
+}
+
+const renderField = (field: InspectionField, value: any, onChange: InspectionFormProps['onChange']) => {
+  switch (field.type) {
+    case 'text':
+      return (
+        <input
+          type="text"
+          className="mt-1 block w-full px-3 py-2 border border-neutral rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+          value={value as string || ''}
+          onChange={e => onChange(field.id, e.target.value)}
+        />
+      );
+    case 'number':
+      return (
+        <input
+          type="number"
+          className="mt-1 block w-full px-3 py-2 border border-neutral rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+          value={value as number || ''}
+          onChange={e => onChange(field.id, parseFloat(e.target.value))}
+        />
+      );
+    case 'boolean':
+      return (
+        <input
+          type="checkbox"
+          className="h-4 w-4 text-primary focus:ring-primary border-neutral rounded"
+          checked={!!value}
+          onChange={e => onChange(field.id, e.target.checked)}
+        />
+      );
+    case 'select':
+      return (
+        <select
+          className="mt-1 block w-full px-3 py-2 border border-neutral rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+          value={value as string || ''}
+          onChange={e => onChange(field.id, e.target.value)}
+        >
+          <option value="">Selecione</option>
+          {field.options && field.options.map(opt => (
+            <option key={opt} value={opt}>{opt}</option>
+          ))}
+        </select>
+      );
+    default:
+      return null;
+  }
+};
+
+const InspectionForm: React.FC<InspectionFormProps> = ({ answers, onChange }) => {
+  return (
+    <form className="space-y-6">
+      {COMPLETE_INSPECTION_SECTIONS.map(section => (
+        <div key={section.id} className="bg-white p-4 rounded-lg shadow">
+          <h3 className="text-lg font-semibold text-neutral-dark mb-4">{section.title}</h3>
+          <div className="space-y-4">
+            {section.fields.map(field => (
+              <div key={field.id} className="flex flex-col">
+                <label className="text-sm font-medium text-neutral-dark">
+                  {field.label}
+                </label>
+                {renderField(field, answers[field.id], onChange)}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </form>
+  );
+};
+
+export default InspectionForm;

--- a/constants.ts
+++ b/constants.ts
@@ -12,6 +12,7 @@ export const ROUTES = {
   DASHBOARD: "/dashboard",
   INSPECTIONS: "/inspections",
   INSPECTION_DETAIL: "/inspections/:id",
+  INSPECTION_REPORT_FORM: "/inspections/:id/report",
   NEW_INSPECTION: "/inspections/new",
   REPORTS: "/reports",
   CLIENTS: "/clients",

--- a/pages/InspectionDetailPage.tsx
+++ b/pages/InspectionDetailPage.tsx
@@ -383,13 +383,22 @@ const InspectionDetailPage: React.FC = () => {
       
 
       <div className="fixed bottom-6 right-6 z-30">
-        <button
-          onClick={() => inspection && generateInspectionPdf(inspection)}
-          className="bg-primary hover:bg-primary-dark text-white font-bold py-3 px-6 rounded-full shadow-lg flex items-center"
-        >
-          <FileText className="w-5 h-5 mr-2" />
-          Gerar Laudo PDF
-        </button>
+        <div className="space-y-2 flex flex-col items-end">
+          <button
+            onClick={() => inspection && navigate(ROUTES.INSPECTION_REPORT_FORM.replace(':id', inspection.id))}
+            className="bg-secondary hover:bg-secondary-dark text-white font-bold py-2 px-4 rounded-full shadow flex items-center"
+          >
+            <FileText className="w-4 h-4 mr-2" />
+            Preencher Laudo
+          </button>
+          <button
+            onClick={() => inspection && generateInspectionPdf(inspection)}
+            className="bg-primary hover:bg-primary-dark text-white font-bold py-3 px-6 rounded-full shadow-lg flex items-center"
+          >
+            <FileText className="w-5 h-5 mr-2" />
+            Gerar Laudo PDF
+          </button>
+        </div>
       </div>
 
     </div>

--- a/pages/InspectionReportFormPage.tsx
+++ b/pages/InspectionReportFormPage.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { getInspectionById } from '../services/inspectionService';
+import { Inspection } from '../types';
+import InspectionForm from '../components/reports/InspectionForm';
+import LoadingSpinner from '../components/ui/LoadingSpinner';
+
+const InspectionReportFormPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [inspection, setInspection] = useState<Inspection | null>(null);
+  const [answers, setAnswers] = useState<Record<string, string | number | boolean>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!id) return;
+      setLoading(true);
+      const data = await getInspectionById(id);
+      if (data) setInspection(data);
+      setLoading(false);
+    };
+    fetchData();
+  }, [id]);
+
+  const handleChange = (fieldId: string, value: string | number | boolean) => {
+    setAnswers(prev => ({ ...prev, [fieldId]: value }));
+  };
+
+  if (loading) return <div className="flex justify-center items-center h-screen"><LoadingSpinner size="lg" /></div>;
+  if (!inspection) return <div className="p-4 text-center">Vistoria não encontrada.</div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-semibold text-neutral-dark">Laudo para {inspection.propertyType}</h1>
+      <p className="text-neutral">{inspection.address}</p>
+      <InspectionForm answers={answers} onChange={handleChange} />
+      <pre className="bg-neutral-light p-4 rounded-md text-xs mt-4 overflow-auto">
+        {JSON.stringify(answers, null, 2)}
+      </pre>
+    </div>
+  );
+};
+
+export default InspectionReportFormPage;


### PR DESCRIPTION
## Summary
- add new route constant for laudo form
- render InspectionReportFormPage with dynamic form
- include InspectionForm component that maps inspectionTemplate questions
- link from inspection detail to the new laudo form

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f432fba308322994ee49d691ffaa8