### PR TITLE
Add inspection panel tabs

### DIFF
--- a/pages/InspectionDetailPage.tsx
+++ b/pages/InspectionDetailPage.tsx
@@ -30,6 +30,20 @@ const InspectionDetailPage: React.FC = () => {
   const [externalReportType, setExternalReportType] = useState<'SISDEA' | 'OUTRO'>('OUTRO');
   const [isAddingExternalReport, setIsAddingExternalReport] = useState(false);
 
+  const tabList = [
+    { id: 'detalhes', label: 'Detalhamento' },
+    { id: 'localizacao', label: 'Localização' },
+    { id: 'sla', label: 'SLA' },
+    { id: 'agendamentos', label: 'Agendamentos' },
+    { id: 'anexos', label: 'Anexos' },
+    { id: 'laudos', label: 'Laudos' },
+    { id: 'despesas', label: 'Despesas' },
+    { id: 'pendencias', label: 'Pendências' },
+    { id: 'publicacoes', label: 'Publicações' },
+  ] as const;
+  type TabId = typeof tabList[number]['id'];
+  const [activeTab, setActiveTab] = useState<TabId>('detalhes');
+
 
   const fetchInspection = useCallback(async () => {
     if (!id) {
@@ -380,7 +394,121 @@ const InspectionDetailPage: React.FC = () => {
           </div>
         </div>
       </div>
-      
+
+      <div className="bg-white p-6 rounded-lg shadow-md">
+        <div className="flex border-b border-neutral-light mb-4">
+          {tabList.map(t => (
+            <button
+              key={t.id}
+              onClick={() => setActiveTab(t.id)}
+              className={`mr-3 pb-2 text-sm font-medium ${activeTab === t.id ? 'border-b-2 border-primary text-primary-dark' : 'text-neutral-dark hover:text-primary-dark'}`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <div className="text-sm space-y-2">
+          {activeTab === 'detalhes' && (
+            <div>
+              <p><strong>ID:</strong> {inspection.id}</p>
+              <p><strong>Cliente:</strong> {inspection.clientName}</p>
+              <p><strong>Tipo:</strong> {inspection.propertyType}</p>
+            </div>
+          )}
+          {activeTab === 'localizacao' && (
+            <div>
+              <p>{inspection.address}</p>
+              {inspection.locationHistory && inspection.locationHistory.length > 0 && (
+                <ul className="list-disc pl-4 mt-2">
+                  {inspection.locationHistory.map(h => (
+                    <li key={h.id}>{new Date(h.date).toLocaleDateString('pt-BR')} - {h.address} ({h.user})</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+          {activeTab === 'sla' && (
+            <div>
+              {inspection.slaEvents && inspection.slaEvents.length > 0 ? (
+                <ul className="space-y-1">
+                  {inspection.slaEvents.map(ev => (
+                    <li key={ev.id} className="flex justify-between">
+                      <span>{ev.name}</span>
+                      <span>{ev.status}{ev.completedAt ? ` - ${new Date(ev.completedAt).toLocaleDateString('pt-BR')}` : ''}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : <p>Nenhum evento registrado.</p>}
+            </div>
+          )}
+          {activeTab === 'agendamentos' && (
+            <div>
+              {inspection.schedules && inspection.schedules.length > 0 ? (
+                <ul className="space-y-1">
+                  {inspection.schedules.map(sch => (
+                    <li key={sch.id}>{new Date(sch.date).toLocaleDateString('pt-BR')} {sch.time} - {sch.note || ''} ({sch.createdBy})</li>
+                  ))}
+                </ul>
+              ) : <p>Nenhum agendamento.</p>}
+            </div>
+          )}
+          {activeTab === 'anexos' && (
+            <div>
+              {inspection.attachments && inspection.attachments.length > 0 ? (
+                <ul className="space-y-1">
+                  {inspection.attachments.map(att => (
+                    <li key={att.id}>{att.name} - {att.type} ({(att.size/1024).toFixed(1)} KB)</li>
+                  ))}
+                </ul>
+              ) : <p>Nenhum anexo.</p>}
+            </div>
+          )}
+          {activeTab === 'laudos' && (
+            <div>
+              {inspection.externalReports && inspection.externalReports.length > 0 ? (
+                <ul className="space-y-1">
+                  {inspection.externalReports.map(rep => (
+                    <li key={rep.id}>{rep.name}</li>
+                  ))}
+                </ul>
+              ) : <p>Nenhum laudo gerado.</p>}
+            </div>
+          )}
+          {activeTab === 'despesas' && (
+            <div>
+              {inspection.expenses && inspection.expenses.length > 0 ? (
+                <ul className="space-y-1">
+                  {inspection.expenses.map(exp => (
+                    <li key={exp.id}>{exp.description}: R$ {exp.amount.toFixed(2)}</li>
+                  ))}
+                </ul>
+              ) : <p>Nenhuma despesa cadastrada.</p>}
+            </div>
+          )}
+          {activeTab === 'pendencias' && (
+            <div>
+              {inspection.pendingItems && inspection.pendingItems.length > 0 ? (
+                <ul className="space-y-1">
+                  {inspection.pendingItems.map(p => (
+                    <li key={p.id}>{p.description} - {p.status}</li>
+                  ))}
+                </ul>
+              ) : <p>Sem pendências.</p>}
+            </div>
+          )}
+          {activeTab === 'publicacoes' && (
+            <div>
+              {inspection.publications && inspection.publications.length > 0 ? (
+                <ul className="space-y-1">
+                  {inspection.publications.map(pub => (
+                    <li key={pub.id}>{new Date(pub.createdAt).toLocaleDateString('pt-BR')} - {pub.author}: {pub.message}</li>
+                  ))}
+                </ul>
+              ) : <p>Nenhuma publicação.</p>}
+            </div>
+          )}
+        </div>
+      </div>
 
       <div className="fixed bottom-6 right-6 z-30">
         <div className="space-y-2 flex flex-col items-end">

--- a/services/inspectionService.ts
+++ b/services/inspectionService.ts
@@ -23,6 +23,13 @@ let inspections: Inspection[] = [
         { id: 'task-1-2', inspectionId: '1', description: 'Preparar equipamento fotográfico.', status: TaskStatus.PENDENTE, createdAt: new Date('2024-08-11T10:00:00Z') }
     ],
     externalReports: [],
+    slaEvents: [],
+    schedules: [],
+    attachments: [],
+    expenses: [],
+    pendingItems: [],
+    publications: [],
+    locationHistory: [],
   },
   {
     id: '2',
@@ -49,7 +56,14 @@ let inspections: Inspection[] = [
     ],
     externalReports: [
         { id: 'er-2-1', name: 'Laudo_SISDEA_Ref123.pdf', type: 'SISDEA', uploadedAt: new Date('2024-08-21T10:00:00Z'), url: '#' }
-    ]
+    ],
+    slaEvents: [],
+    schedules: [],
+    attachments: [],
+    expenses: [],
+    pendingItems: [],
+    publications: [],
+    locationHistory: [],
   },
   {
     id: '3',
@@ -71,6 +85,13 @@ let inspections: Inspection[] = [
       { id: 'task-3-2', inspectionId: '3', description: 'Solicitar plantas originais.', status: TaskStatus.PENDENTE, createdAt: new Date() }
     ],
     externalReports: [],
+    slaEvents: [],
+    schedules: [],
+    attachments: [],
+    expenses: [],
+    pendingItems: [],
+    publications: [],
+    locationHistory: [],
   },
 ];
 
@@ -110,6 +131,13 @@ export const createInspection = async (newInspectionData: Omit<Inspection, 'id' 
     presetName: newInspectionData.presetName,
     tasks: [], // Initialize with empty tasks array
     externalReports: [], // Initialize with empty external reports array
+    slaEvents: [],
+    schedules: [],
+    attachments: [],
+    expenses: [],
+    pendingItems: [],
+    publications: [],
+    locationHistory: [],
   };
   inspections.push(inspection);
   return JSON.parse(JSON.stringify(inspection)); // Return deep copy
@@ -121,12 +149,19 @@ export const updateInspection = async (id: string, updatedData: Partial<Inspecti
   if (index !== -1) {
     // Ensure tasks and externalReports are not overwritten if not provided in updatedData
     const currentInspection = inspections[index];
-    inspections[index] = { 
-        ...currentInspection, 
+    inspections[index] = {
+        ...currentInspection,
         ...updatedData,
         tasks: updatedData.tasks !== undefined ? updatedData.tasks : currentInspection.tasks,
-        externalReports: updatedData.externalReports !== undefined ? updatedData.externalReports : currentInspection.externalReports 
-     }; // Removed trailing comma here
+        externalReports: updatedData.externalReports !== undefined ? updatedData.externalReports : currentInspection.externalReports,
+        slaEvents: updatedData.slaEvents !== undefined ? updatedData.slaEvents : currentInspection.slaEvents,
+        schedules: updatedData.schedules !== undefined ? updatedData.schedules : currentInspection.schedules,
+        attachments: updatedData.attachments !== undefined ? updatedData.attachments : currentInspection.attachments,
+        expenses: updatedData.expenses !== undefined ? updatedData.expenses : currentInspection.expenses,
+        pendingItems: updatedData.pendingItems !== undefined ? updatedData.pendingItems : currentInspection.pendingItems,
+        publications: updatedData.publications !== undefined ? updatedData.publications : currentInspection.publications,
+        locationHistory: updatedData.locationHistory !== undefined ? updatedData.locationHistory : currentInspection.locationHistory
+     };
     return JSON.parse(JSON.stringify(inspections[index])); // Return deep copy
   }
   return undefined;

--- a/types.ts
+++ b/types.ts
@@ -55,6 +55,62 @@ export interface ExternalReport {
   uploadedAt: Date;
 }
 
+export interface SLAEvent {
+  id: string;
+  name: string;
+  deadline?: Date;
+  status: string;
+  completedAt?: Date;
+}
+
+export interface ScheduleEntry {
+  id: string;
+  date: Date;
+  time: string;
+  note?: string;
+  createdBy: string;
+  createdAt: Date;
+}
+
+export interface Attachment {
+  id: string;
+  name: string;
+  description?: string;
+  url: string;
+  size: number;
+  type: string;
+  uploadedAt: Date;
+  uploadedBy: string;
+}
+
+export interface Expense {
+  id: string;
+  description: string;
+  amount: number;
+  receiptUrl?: string;
+}
+
+export interface PendingItem {
+  id: string;
+  description: string;
+  status: string;
+  dueDate?: Date;
+}
+
+export interface Publication {
+  id: string;
+  author: string;
+  message: string;
+  createdAt: Date;
+}
+
+export interface LocationHistoryItem {
+  id: string;
+  date: Date;
+  user: string;
+  address: string;
+}
+
 export interface Inspection {
   id: string;
   address: string;
@@ -70,6 +126,13 @@ export interface Inspection {
   generatedReportSummary?: string; 
   tasks?: Task[];
   externalReports?: ExternalReport[];
+  slaEvents?: SLAEvent[];
+  schedules?: ScheduleEntry[];
+  attachments?: Attachment[];
+  expenses?: Expense[];
+  pendingItems?: PendingItem[];
+  publications?: Publication[];
+  locationHistory?: LocationHistoryItem[];
 }
 
 export type ClientType = 'BANK' | 'CONSTRUCTION_COMPANY' | 'INDIVIDUAL' | 'OTHER';


### PR DESCRIPTION
## Summary
- extend Inspection types to cover schedules, attachments, expenses and other lists
- track these new fields in the mock inspection service
- add tabbed panel on `InspectionDetailPage` to display extra info

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f46db98a883228a19d235994f7167