### PR TITLE
Implement fuel cost service

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ This contains everything you need to run your app locally.
 2. Run the app:
    `npm run dev`
 
+## Cálculo de Custo de Combustível
+
+O arquivo `services/costService.ts` possui utilidades para estimar o gasto de combustível até um determinado endereço. O cálculo usa o serviço público do OpenStreetMap para geocodificação e rota, considerando:
+
+- Endereço de origem definido em `COMPANY_BASE_ADDRESS` em `constants.ts`;
+- Preço do litro de combustível;
+- Consumo médio do veículo (km por litro);
+- Valor total de pedágios (opcional).
+
+O resultado inclui distância, litros necessários e o custo total da viagem.
+
 ## Complete Inspection Template
 
 The file `inspectionTemplate.ts` lists all sections and fields used in the

--- a/constants.ts
+++ b/constants.ts
@@ -57,3 +57,6 @@ export const CHECKLIST_PRESETS = {
   simplified: { name: 'Simplificado', items: SIMPLIFIED_CHECKLIST_ITEMS },
   complete: { name: 'Completo', items: COMPLETE_CHECKLIST_ITEMS },
 } as const;
+
+// Endereço base utilizado para cálculos de deslocamento
+export const COMPANY_BASE_ADDRESS = 'Praça da Sé, São Paulo - SP';

--- a/services/costService.ts
+++ b/services/costService.ts
@@ -1,0 +1,59 @@
+import { COMPANY_BASE_ADDRESS } from '../constants';
+
+export interface FuelCostOptions {
+  destination: string;
+  fuelPricePerLiter: number; // Cost of fuel per liter (BRL)
+  fuelEfficiencyKmPerLiter: number; // Vehicle efficiency
+  tolls?: number; // Total toll cost in BRL
+  origin?: string; // optional override of origin address
+}
+
+export interface FuelCostResult {
+  distanceKm: number;
+  fuelLiters: number;
+  fuelCost: number;
+  tollCost: number;
+  totalCost: number;
+}
+
+type Coordinates = { lat: number; lon: number };
+
+const geocodeAddress = async (address: string): Promise<Coordinates> => {
+  const params = new URLSearchParams({ q: address, format: 'json', limit: '1' });
+  const res = await fetch(`https://nominatim.openstreetmap.org/search?${params.toString()}`, {
+    headers: { 'User-Agent': 'ArchiEng Dashboard' }
+  });
+  if (!res.ok) throw new Error('Geocoding failed');
+  const data = await res.json();
+  if (!Array.isArray(data) || data.length === 0) throw new Error('Address not found');
+  return { lat: parseFloat(data[0].lat), lon: parseFloat(data[0].lon) };
+};
+
+const getDrivingDistanceKm = async (from: Coordinates, to: Coordinates): Promise<number> => {
+  const url = `https://router.project-osrm.org/route/v1/driving/${from.lon},${from.lat};${to.lon},${to.lat}?overview=false`;
+  const res = await fetch(url, { headers: { 'User-Agent': 'ArchiEng Dashboard' } });
+  if (!res.ok) throw new Error('Routing failed');
+  const data = await res.json();
+  if (!data.routes || !data.routes[0]) throw new Error('Route not found');
+  return data.routes[0].distance / 1000; // meters to km
+};
+
+export const calculateFuelCost = async (options: FuelCostOptions): Promise<FuelCostResult> => {
+  const originAddress = options.origin || COMPANY_BASE_ADDRESS;
+  const tolls = options.tolls ?? 0;
+
+  try {
+    const [originCoords, destCoords] = await Promise.all([
+      geocodeAddress(originAddress),
+      geocodeAddress(options.destination)
+    ]);
+    const distanceKm = await getDrivingDistanceKm(originCoords, destCoords);
+    const fuelLiters = distanceKm / options.fuelEfficiencyKmPerLiter;
+    const fuelCost = fuelLiters * options.fuelPricePerLiter;
+    const totalCost = fuelCost + tolls;
+    return { distanceKm, fuelLiters, fuelCost, tollCost: tolls, totalCost };
+  } catch (e) {
+    console.error('Failed to calculate fuel cost:', e);
+    return { distanceKm: 0, fuelLiters: 0, fuelCost: 0, tollCost: tolls, totalCost: tolls };
+  }
+};

--- a/types.ts
+++ b/types.ts
@@ -173,3 +173,19 @@ export interface GroundingMetadata {
   groundingChunks?: GroundingChunk[];
   // Other grounding metadata fields
 }
+
+export interface FuelCostOptions {
+  destination: string;
+  fuelPricePerLiter: number;
+  fuelEfficiencyKmPerLiter: number;
+  tolls?: number;
+  origin?: string;
+}
+
+export interface FuelCostResult {
+  distanceKm: number;
+  fuelLiters: number;
+  fuelCost: number;
+  tollCost: number;
+  totalCost: number;
+}


### PR DESCRIPTION
## Summary
- add base address constant for fuel cost calculations
- implement `calculateFuelCost` service using OpenStreetMap APIs
- document fuel cost service in README
- expose fuel cost types in `types.ts`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ffcde933c8322a7914c61699cd873