### PR TITLE
Add travel cost simulator

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import ComparablesPage from './pages/ComparablesPage';
 import CalendarPage from './pages/CalendarPage';
 import SettingsPage from './pages/SettingsPage';
 import SuperAdminPage from './pages/SuperAdminPage';
+import CostSimulatorPage from './pages/CostSimulatorPage';
 import { ROUTES } from './constants';
 
 const App: React.FC = () => {
@@ -36,6 +37,7 @@ const App: React.FC = () => {
           <Route path={ROUTES.CALENDAR} element={<CalendarPage />} />
           <Route path={ROUTES.REPORTS} element={<ReportsPage />} />
           <Route path={ROUTES.COMPARABLES} element={<ComparablesPage />} />
+          <Route path={ROUTES.COST_SIMULATOR} element={<CostSimulatorPage />} />
           <Route path={ROUTES.SETTINGS} element={<SettingsPage />} />
           <Route path={ROUTES.SUPER_ADMIN} element={<SuperAdminPage />} />
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ O arquivo `services/costService.ts` possui utilidades para estimar o gasto de co
 
 O resultado inclui distância, litros necessários e o custo total da viagem.
 
+### Página de Simulação
+
+Use a rota `/custo-deslocamento` para abrir a página de simulação de custo de deslocamento. Ela permite calcular o valor aproximado partindo de `COMPANY_BASE_ADDRESS` (atualmente "Rua Dionisio Erthal 69, Santa Rosa, Niterói RJ") até qualquer destino.
+
 ## Complete Inspection Template
 
 The file `inspectionTemplate.ts` lists all sections and fields used in the

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   ListPlus,
   Users,
+  Car,
   List,
   Settings as SettingsIcon,
 } from 'lucide-react';
@@ -86,6 +87,12 @@ const Sidebar: React.FC = () => {
           label="CDC"
           currentPath={location.pathname}
           icon={<ListPlus className="w-5 h-5" />}
+        />
+        <NavItem
+          to={ROUTES.COST_SIMULATOR}
+          label="Deslocamento"
+          currentPath={location.pathname}
+          icon={<Car className="w-5 h-5" />}
         />
         <NavItem
           to={ROUTES.CLIENTS}

--- a/constants.ts
+++ b/constants.ts
@@ -21,6 +21,7 @@ export const ROUTES = {
   CALENDAR: "/calendar",
   SETTINGS: "/settings",
   COMPARABLES: "/comparables",
+  COST_SIMULATOR: "/custo-deslocamento",
   SUPER_ADMIN: "/super-admin",
 };
 
@@ -59,4 +60,4 @@ export const CHECKLIST_PRESETS = {
 } as const;
 
 // Endereço base utilizado para cálculos de deslocamento
-export const COMPANY_BASE_ADDRESS = 'Praça da Sé, São Paulo - SP';
+export const COMPANY_BASE_ADDRESS = 'Rua Dionisio Erthal 69, Santa Rosa, Niterói RJ';

--- a/pages/CostSimulatorPage.tsx
+++ b/pages/CostSimulatorPage.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import { calculateFuelCost } from '../services/costService';
+import { FuelCostOptions, FuelCostResult } from '../types';
+import { COMPANY_BASE_ADDRESS } from '../constants';
+import LoadingSpinner from '../components/ui/LoadingSpinner';
+
+const CostSimulatorPage: React.FC = () => {
+  const [formData, setFormData] = useState<FuelCostOptions>({
+    destination: '',
+    fuelPricePerLiter: 6,
+    fuelEfficiencyKmPerLiter: 10,
+    tolls: 0,
+    origin: COMPANY_BASE_ADDRESS,
+  });
+  const [result, setResult] = useState<FuelCostResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: name === 'destination' ? value : Number(value),
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await calculateFuelCost(formData);
+      setResult(res);
+    } catch (err) {
+      setError('Falha ao calcular custo.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-semibold text-neutral-dark">Simulador de Custo de Deslocamento</h1>
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow space-y-4 max-w-xl">
+        <div>
+          <label htmlFor="destination" className="block text-sm font-medium text-neutral-dark">Endereço de Destino *</label>
+          <input
+            id="destination"
+            name="destination"
+            type="text"
+            required
+            value={formData.destination}
+            onChange={handleChange}
+            className="mt-1 block w-full px-3 py-2 border border-neutral rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="fuelPricePerLiter" className="block text-sm font-medium text-neutral-dark">Preço do Litro de Combustível (R$)</label>
+          <input
+            id="fuelPricePerLiter"
+            name="fuelPricePerLiter"
+            type="number"
+            step="0.01"
+            value={formData.fuelPricePerLiter}
+            onChange={handleChange}
+            className="mt-1 block w-full px-3 py-2 border border-neutral rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="fuelEfficiencyKmPerLiter" className="block text-sm font-medium text-neutral-dark">Consumo Médio (km/L)</label>
+          <input
+            id="fuelEfficiencyKmPerLiter"
+            name="fuelEfficiencyKmPerLiter"
+            type="number"
+            step="0.1"
+            value={formData.fuelEfficiencyKmPerLiter}
+            onChange={handleChange}
+            className="mt-1 block w-full px-3 py-2 border border-neutral rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="tolls" className="block text-sm font-medium text-neutral-dark">Pedágios (R$)</label>
+          <input
+            id="tolls"
+            name="tolls"
+            type="number"
+            step="0.01"
+            value={formData.tolls}
+            onChange={handleChange}
+            className="mt-1 block w-full px-3 py-2 border border-neutral rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="origin" className="block text-sm font-medium text-neutral-dark">Origem</label>
+          <input
+            id="origin"
+            name="origin"
+            type="text"
+            value={formData.origin}
+            readOnly
+            className="mt-1 block w-full px-3 py-2 border border-neutral rounded-md shadow-sm bg-neutral-light sm:text-sm"
+          />
+        </div>
+        {error && <p className="text-red-600 text-sm bg-red-100 p-2 rounded">{error}</p>}
+        <button type="submit" className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark" disabled={loading}>
+          {loading ? <LoadingSpinner size="sm" color="text-white" /> : 'Calcular'}
+        </button>
+      </form>
+
+      {result && (
+        <div className="bg-white p-6 rounded-lg shadow max-w-xl space-y-2">
+          <p><strong>Distância:</strong> {result.distanceKm.toFixed(2)} km</p>
+          <p><strong>Combustível Necessário:</strong> {result.fuelLiters.toFixed(2)} L</p>
+          <p><strong>Custo de Combustível:</strong> R$ {result.fuelCost.toFixed(2)}</p>
+          <p><strong>Pedágios:</strong> R$ {result.tollCost.toFixed(2)}</p>
+          <p className="font-semibold"><strong>Custo Total:</strong> R$ {result.totalCost.toFixed(2)}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CostSimulatorPage;


### PR DESCRIPTION
## Summary
- add travel cost simulator page
- link to simulator in sidebar and routes
- document simulator page in README
- set base address to Rua Dionisio Erthal 69

## Testing
- `npx vite build` *(fails: Error: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_684ffe8156bc8322ac0d3642531acdce