### PR TITLE
Add offline fallback for fuel cost calculations

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -61,3 +61,5 @@ export const CHECKLIST_PRESETS = {
 
 // Endereço base utilizado para cálculos de deslocamento
 export const COMPANY_BASE_ADDRESS = 'Rua Dionisio Erthal 69, Santa Rosa, Niterói RJ';
+// Approximate coordinates for the base address used when offline
+export const COMPANY_BASE_COORDS = { lat: -22.8991, lon: -43.0957 } as const;

--- a/types.ts
+++ b/types.ts
@@ -13,6 +13,12 @@ export enum ChecklistItemStatus {
   SKIPPED = 'Ignorada',
 }
 
+// Basic latitude/longitude pair used in services like cost simulation
+export interface Coordinates {
+  lat: number;
+  lon: number;
+}
+
 export interface Photo {
   id: string;
   url: string; // Could be a base64 string for local preview or a remote URL


### PR DESCRIPTION
## Summary
- add base coordinates for the company address
- expose `Coordinates` type
- improve cost service with local address mapping and haversine fallback

## Testing
- `npx --yes vite build` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6850074e1ba0832297f7f25dc4a70993