### PR TITLE
Add alternate admin panel view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import CalendarPage from './pages/CalendarPage';
 import SettingsPage from './pages/SettingsPage';
 import SuperAdminPage from './pages/SuperAdminPage';
 import CostSimulatorPage from './pages/CostSimulatorPage';
+import AdminPanelPage from './pages/AdminPanelPage';
 import { ROUTES } from './constants';
 
 const App: React.FC = () => {
@@ -40,6 +41,7 @@ const App: React.FC = () => {
           <Route path={ROUTES.COST_SIMULATOR} element={<CostSimulatorPage />} />
           <Route path={ROUTES.SETTINGS} element={<SettingsPage />} />
           <Route path={ROUTES.SUPER_ADMIN} element={<SuperAdminPage />} />
+          <Route path={ROUTES.ADMIN_PANEL} element={<AdminPanelPage />} />
 
           <Route path="*" element={<Navigate to={ROUTES.DASHBOARD} replace />} />
         </Route>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ O resultado inclui distância, litros necessários e o custo total da viagem.
 
 Use a rota `/custo-deslocamento` para abrir a página de simulação de custo de deslocamento. A calculadora agora considera automaticamente **ida e volta**. Se o campo de pedágio ficar em branco, o valor será buscado na API da TollGuru (é necessário definir `TOLLGURU_API_KEY` no ambiente). O cálculo parte do endereço definido em `COMPANY_BASE_ADDRESS` (atualmente "Rua Dionisio Erthal 69, Santa Rosa, Niterói RJ").
 
+### Admin Panel
+
+Há uma visão alternativa de administração disponível em `/admin`. Ela pode ser usada para experimentar diferentes layouts ou funcionalidades específicas para administradores.
+
 ## Complete Inspection Template
 
 The file `inspectionTemplate.ts` lists all sections and fields used in the

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -106,6 +106,12 @@ const Sidebar: React.FC = () => {
           currentPath={location.pathname}
           icon={<List className="w-5 h-5" />}
         />
+        <NavItem
+          to={ROUTES.ADMIN_PANEL}
+          label="Admin Panel"
+          currentPath={location.pathname}
+          icon={<LayoutGrid className="w-5 h-5" />}
+        />
       </nav>
       <div className="p-4 mt-auto border-t border-neutral-light">
         <NavItem

--- a/constants.ts
+++ b/constants.ts
@@ -23,6 +23,7 @@ export const ROUTES = {
   COMPARABLES: "/comparables",
   COST_SIMULATOR: "/custo-deslocamento",
   SUPER_ADMIN: "/super-admin",
+  ADMIN_PANEL: "/admin",
 };
 
 // Ensure these items fully conform to the ChecklistItem interface structure now

--- a/pages/AdminPanelPage.tsx
+++ b/pages/AdminPanelPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const AdminPanelPage: React.FC = () => {
+  return (
+    <div className="p-6 space-y-8">
+      <h1 className="text-3xl font-semibold text-neutral-dark">Painel Administrativo</h1>
+      <p className="text-neutral">Esta é uma visão alternativa do painel de administração. Use este espaço para adicionar estatísticas ou controles específicos para administradores.</p>
+    </div>
+  );
+};
+
+export default AdminPanelPage;


### PR DESCRIPTION
## Summary
- add AdminPanelPage for alternate admin interface
- register `/admin` route and link from the sidebar
- document new admin panel page in README

## Testing
- `npx vite build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500d8b9878832295e2b0d10b1628b1